### PR TITLE
OS #9270 - Cadastros via editais

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -6,7 +6,6 @@ use MapasCulturais\API;
 use MapasCulturais\App;
 use MapasCulturais\Repositories\Agent;
 use MapasCulturais\Definitions\Taxonomy;
-use CulturaViva\JobTypes\JobsAFormTextUpdater;
 use MapasCulturais\Entities\Opportunity;
 use MapasCulturais\Entities\Registration;
 use MapasCulturais\Plugin as MapasCulturaisPlugin;
@@ -195,10 +194,6 @@ class Plugin extends MapasCulturaisPlugin {
             $app->registerController('rcv', 'RCV\Controllers\Rcv');
         }
 
-        if(!$app->getRegisteredJobType(JobsAFormTextUpdater::SLUG)){
-            $app->registerJobType(new JobsAFormTextUpdater(JobsAFormTextUpdater::SLUG));
-        }
-            
         $this->registerMetadata('MapasCulturais\Entities\Agent', 'rcv_registration', [
             'label' => 'Inscrição da oraganização',
             'type' => 'entity',

--- a/db-updates.php
+++ b/db-updates.php
@@ -3,7 +3,6 @@
 use MapasCulturais\App;
 use MapasCulturais as M;
 use MapasCulturais\Entities\Registration;
-use CulturaViva\JobTypes\JobsAFormTextUpdater;
 use MapasCulturais\Entities\Agent;
 use MapasCulturais\Entities\RegistrationSpaceRelation;
 use MapasCulturais\Entities\Space;
@@ -914,21 +913,6 @@ return [
                 'object_type' => 'MapasCulturais\Entities\Registration'
             ]);
         }
-    },
-
-    'Atualiza Job de acompanhamento das inscrições sinalizadas com Sim. Estou ciente de que a minha certificação dependerá da avaliação pela Comissão de Seleção do edital da Cultura Viva em que estou concorrendo' => function(){
-        $app = App::i();
-        $start_string = date('Y-m-d 00:00:00',strtotime('tomorrow'));
-        $interval_string = '+24 hours';
-        $iterations = 3650;
-
-        $job = $app->enqueueOrReplaceJob(JobsAFormTextUpdater::SLUG,[],$start_string,$interval_string,$iterations);
-        $job->save(true);
-        $job->subsite = $app->repo('Subsite')->find('8');
-
-        $app->log->debug('Deletando JobsAFormTextUpdater');
-
-        return false;
     },
 
     'define metadado rcv_registration nas organizações que ainda não possuem' => function () {


### PR DESCRIPTION
## Resumo

Remove do plugin RCV o registro do job `JobsAFormTextUpdater` e a migração em `db-updates.php` que criava/agendava esse job recorrente.

## O que mudou

- **`Plugin.php`**: removidos o import e o `registerJobType` de `JobsAFormTextUpdater` no bootstrap do plugin.
- **`db-updates.php`**: removida a migration que enfileirava o job diário (3650 execuções) para atualizar o acompanhamento de inscrições com o campo de ciência da certificação.

## Motivação

O job de atualização de texto do formulário A não é mais necessário no fluxo do RCV; a lógica deixa de ser registrada e agendada automaticamente na instalação/atualização do plugin.